### PR TITLE
Update Gems & Release version 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.6.0 / 2016-12-09
+
+### Breaking changes
+
+* Pull request [#9][https://github.com/fnichol/finstyle/issues/9]: Update Rubocop & Release version 1.6.0. ([@afiune][https://github.com/afiune])
+
 ## 1.5.0 / 2015-06-29
 
 ### Breaking changes
@@ -68,5 +74,6 @@ The initial release.
 [#2]: https://github.com/fnichol/finstyle/issues/2
 [#3]: https://github.com/fnichol/finstyle/issues/3
 [#4]: https://github.com/fnichol/finstyle/issues/4
+[#8]: https://github.com/fnichol/finstyle/issues/8
 [@cwjohnston]: https://github.com/cwjohnston
 [@fnichol]: https://github.com/fnichol

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -959,7 +959,7 @@ Lint/ShadowingOuterLocalVariable:
                  for block arguments or block local variables.
   Enabled: true
 
-Lint/SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Description: >-
                  Put a space between a method name and the first argument
                  in a method call without parentheses.

--- a/finstyle.gemspec
+++ b/finstyle.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency("rubocop", Finstyle::RUBOCOP_VERSION)
 
   spec.add_development_dependency("bundler", "~> 1.6")
-  spec.add_development_dependency("rake", "~> 10.0")
+  spec.add_development_dependency("rake", "~> 12.0")
   spec.add_development_dependency("countloc", "~> 0.4")
 
   # style and complexity libraries are tightly version pinned as newer releases
   # may introduce new and undesireable style choices which would be immediately
   # enforced in CI
-  spec.add_development_dependency("cane", "2.6.2")
+  spec.add_development_dependency("cane", "3.0.0")
 end

--- a/lib/finstyle/version.rb
+++ b/lib/finstyle/version.rb
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 
 module Finstyle
-  VERSION = "1.5.1.dev"
+  VERSION = "1.6.0"
 
-  RUBOCOP_VERSION = "0.32.1"
+  RUBOCOP_VERSION = "0.39.0"
 end


### PR DESCRIPTION
We need to update some gems like rubocop rake and cane so that our tests
in chefdk and test-kitchen passes.

Signed-off-by: Salim Afiune <afiune@chef.io>